### PR TITLE
Added preset configurations for Focusrite Scarlett 2i2 & Focusrite Scarlett Solo

### DIFF
--- a/Preset Configurations/RS_ASIO Scarlett 2i2.ini
+++ b/Preset Configurations/RS_ASIO Scarlett 2i2.ini
@@ -1,0 +1,31 @@
+[Config]
+EnableWasapi=0
+EnableAsio=1
+
+[Asio]
+; available buffer size modes:
+;    driver - respect buffer size setting set in the driver
+;    host   - use a buffer size as close as possible as that requested by the host application
+;    custom - use the buffer size specified in CustomBufferSize field
+BufferSizeMode=custom
+CustomBufferSize=192
+
+[Asio.Output]
+Driver=Focusrite USB ASIO
+EnableSoftwareEndpointVolumeControl=1
+EnableSoftwareMasterVolumeControl=1
+SoftwareMasterVolumePercent=100
+
+[Asio.Input.0]
+Driver=Focusrite USB ASIO
+Channel=0
+EnableSoftwareEndpointVolumeControl=1
+EnableSoftwareMasterVolumeControl=1
+SoftwareMasterVolumePercent=100
+
+; [Asio.Input.1]
+; Driver=Focusrite USB ASIO
+; Channel=1
+; EnableSoftwareEndpointVolumeControl=1
+; EnableSoftwareMasterVolumeControl=1
+; SoftwareMasterVolumePercent=100

--- a/Preset Configurations/RS_ASIO Scarlett Solo.ini
+++ b/Preset Configurations/RS_ASIO Scarlett Solo.ini
@@ -1,0 +1,31 @@
+[Config]
+EnableWasapi=0
+EnableAsio=1
+
+[Asio]
+; available buffer size modes:
+;    driver - respect buffer size setting set in the driver
+;    host   - use a buffer size as close as possible as that requested by the host application
+;    custom - use the buffer size specified in CustomBufferSize field
+BufferSizeMode=custom
+CustomBufferSize=192
+
+[Asio.Output]
+Driver=Focusrite USB ASIO
+EnableSoftwareEndpointVolumeControl=1
+EnableSoftwareMasterVolumeControl=1
+SoftwareMasterVolumePercent=100
+
+[Asio.Input.0]
+Driver=Focusrite USB ASIO
+Channel=1
+EnableSoftwareEndpointVolumeControl=1
+EnableSoftwareMasterVolumeControl=1
+SoftwareMasterVolumePercent=100
+
+; [Asio.Input.1]
+; Driver=Focusrite USB ASIO
+; Channel=1
+; EnableSoftwareEndpointVolumeControl=1
+; EnableSoftwareMasterVolumeControl=1
+; SoftwareMasterVolumePercent=100


### PR DESCRIPTION
I noticed a lot of people were having issues with configuring RS ASIO for the Focusrite series of interfaces, so I created two presets for the most popular configurations.

- Setup for a buffer size of 192
- Both inputs are setup for the 2i2, with the second input being commented out for Multiplayer (to make it work just remove the commentation)
- The files have to be renamed back to RS_ASIO.ini to work in Rocksmith

I hope this can help people use this tool a lot easier now!