### PR TITLE
Add descriptions for Asus Strix Soar

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It patches game code at runtime to allow intervening in the process of WASAPI de
 
 ## Audio Interfaces reported to work well
 
+- [Asus Strix Soar](docs/asus_strix_soar/README.md)
 - Audient iD4
 - [Behringer MIC2 USB](docs/behringer_mic2usb/README.md), using ASIO4All
 - Behringer U-Phoria UM2 [(see this for more details)](https://github.com/mdias/rs_asio/issues/7)

--- a/docs/asus_strix_soar/README.md
+++ b/docs/asus_strix_soar/README.md
@@ -1,0 +1,61 @@
+# Asus Strix Soar
+
+Works without problems using the driver supplied buffer size.
+Rocksmith's `LatencyBuffer` can be set to 3 on faster systems.
+
+Instrument can only be heard when using `EnableWasapiInputs=1` so that the RealTone Cable is found and used by the Software.
+
+## Config file
+
+**RS_ASIO.ini**
+
+```ini
+[Config]
+EnableWasapiOutputs=0
+EnableWasapiInputs=1
+EnableAsio=1
+
+[Asio]
+; available buffer size modes:
+;    driver - respect buffer size setting set in the driver
+;    host   - use a buffer size as close as possible as that requested by the host application
+;    custom - use the buffer size specified in CustomBufferSize field
+BufferSizeMode=driver
+CustomBufferSize=
+
+[Asio.Output]
+Driver=STRIX SOUND CARD ASIO
+BaseChannel=0
+EnableSoftwareEndpointVolumeControl=1
+EnableSoftwareMasterVolumeControl=1
+SoftwareMasterVolumePercent=100
+
+[Asio.Input.0]
+Driver=
+Channel=0
+EnableSoftwareEndpointVolumeControl=1
+EnableSoftwareMasterVolumeControl=1
+SoftwareMasterVolumePercent=100
+
+[Asio.Input.1]
+Driver=
+Channel=1
+EnableSoftwareEndpointVolumeControl=1
+EnableSoftwareMasterVolumeControl=1
+SoftwareMasterVolumePercent=100
+```
+
+**Rocksmith.ini**
+```ini
+[Audio]
+EnableMicrophone=0
+ExclusiveMode=1
+LatencyBuffer=3
+ForceDefaultPlaybackDevice=
+ForceWDM=0
+ForceDirectXSink=0
+DumpAudioLog=0
+MaxOutputBufferSize=0
+RealToneCableOnly=0
+Win32UltraLowLatencyMode=1
+```


### PR DESCRIPTION
This adds the sound card Strix Soar by Asus to the compatibility list and adds an entry in the doc folder.
While the card is mostly a gaming card, the card driver still supports ASIO and works like a charm.

Thanks for this project - this really helps a lot. Finally I can use the software without latency problems!