### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Some people have had success using RS ASIO with [wineasio](https://www.wineasio.
 - Lexicon Alpha
 - [Line6 AMPLIFi 75](https://github.com/mdias/rs_asio/issues/97) **Some limitations apply. Follow the link for more information.**
 - Line6 HX Stomp
+- Line6 POD Go
 - M-Audio 2x2
 - [M-Audio AIR 192|4](https://github.com/mdias/rs_asio/issues/98)
 - [M-Audio Fast Track Ultra 8R](https://github.com/mdias/rs_asio/issues/135)


### PR DESCRIPTION
Very happy to report this works with the Line 6 POD Go guitar processor, as released in 2020. Thank you!

[Asio.Output]
Driver=ASIO POD Go
BaseChannel=0
AltBaseChannel=
EnableSoftwareEndpointVolumeControl=1
EnableSoftwareMasterVolumeControl=1
SoftwareMasterVolumePercent=100

[Asio.Input.0]
Driver=ASIO POD Go
Channel=3
EnableSoftwareEndpointVolumeControl=1
EnableSoftwareMasterVolumeControl=1
SoftwareMasterVolumePercent=150