### PR TITLE
Added BOSS GT-1 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Some people have had success using RS ASIO with [wineasio](https://www.wineasio.
 - [Behringer UMC404HD](https://github.com/mdias/rs_asio/issues/13)
 - [Behringer XENIX Q502USB](https://github.com/mdias/rs_asio/issues/132)
 - [Behringer XR18](https://github.com/mdias/rs_asio/issues/72)
+- BOSS GT-1
 - [BOSS Katana MkII](docs/katana_mk2/README.md)
 - ESI MAYA22 USB
 - [ESI MAYA44 eX](https://github.com/mdias/rs_asio/issues/134)


### PR DESCRIPTION
I added the BOSS GT-1 to the list of supported devices. Below is the RS_ASIO.ini I'm using. The small buffer size is aggressive, but is working well for me.

```
[Config]
EnableWasapi=0
EnableAsio=1

[Asio]
; available buffer size modes:
;    driver - respect buffer size setting set in the driver
;    host   - use a buffer size as close as possible as that requested by the host application
;    custom - use the buffer size specified in CustomBufferSize field
BufferSizeMode=driver
CustomBufferSize=48

[Asio.Output]
Driver=GT-1
EnableSoftwareEndpointVolumeControl=1
EnableSoftwareMasterVolumeControl=1
SoftwareMasterVolumePercent=100

[Asio.Input.0]
Driver=GT-1
Channel=0
EnableSoftwareEndpointVolumeControl=1
EnableSoftwareMasterVolumeControl=1
SoftwareMasterVolumePercent=100

[Asio.Input.1]
Driver=
Channel=1
EnableSoftwareEndpointVolumeControl=1
EnableSoftwareMasterVolumeControl=1
SoftwareMasterVolumePercent=100
```