### PR TITLE
Added MixPre 6 to supported list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Some people have had success using RS ASIO with [wineasio](https://www.wineasio.
 - [Solid State Logic SSL2+](https://github.com/mdias/rs_asio/issues/167)
 - [SoundCraft Notepad-8FX](https://github.com/mdias/rs_asio/issues/86)
 - [SoundCraft Notepad-12FX](https://github.com/mdias/rs_asio/issues/86)
+- Sound Devices MixPre-6 II
 - [Steinberg UR22C](https://github.com/mdias/rs_asio/issues/124)
 - [Steinberg UR44C](https://github.com/mdias/rs_asio/issues/130)
 - [Steinberg UR22mkII](docs/steinberg_ur12/README.md)


### PR DESCRIPTION
Added Sound Devices MixPre 6 MK2 to supported list. Just works, no problems at all (tested single player only).
I think other mixpre devices should work equally well.

AsioInput0 Channel=1 is MixPre Channel 2. Ive got a microphone on Channel 1 (Asio Channel=0).

[Config]
EnableWasapiOutputs=0
EnableWasapiInputs=0
EnableAsio=1

[Asio]
; available buffer size modes:
;    driver - respect buffer size setting set in the driver
;    host   - use a buffer size as close as possible as that requested by the host application
;    custom - use the buffer size specified in CustomBufferSize field
BufferSizeMode=driver
CustomBufferSize=

[Asio.Output]
Driver=MixPre ASIO driver
BaseChannel=0
AltBaseChannel=
EnableSoftwareEndpointVolumeControl=1
EnableSoftwareMasterVolumeControl=1
SoftwareMasterVolumePercent=100

[Asio.Input.0]
Driver=MixPre ASIO driver
Channel=1
EnableSoftwareEndpointVolumeControl=1
EnableSoftwareMasterVolumeControl=1
SoftwareMasterVolumePercent=100

[Asio.Input.1]
Driver=
Channel=0
EnableSoftwareEndpointVolumeControl=1
EnableSoftwareMasterVolumeControl=1
SoftwareMasterVolumePercent=100

[Asio.Input.Mic]
Driver=
Channel=1
EnableSoftwareEndpointVolumeControl=1
EnableSoftwareMasterVolumeControl=1
SoftwareMasterVolumePercent=100