### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Some people have had success using RS ASIO with [wineasio](https://www.wineasio.
 - [Yamaha THR30IIW](https://github.com/mdias/rs_asio/issues/210)
 - [Zoom G2.1NU](https://github.com/mdias/rs_asio/issues/400)
 - [Zoom G2.1DM](https://github.com/mdias/rs_asio/issues/400)
+- Zoom H2N
 - [Zoom H6](https://github.com/mdias/rs_asio/issues/198)
 - Zoom R24
 - [Zoom U-22](https://github.com/mdias/rs_asio/issues/179)


### PR DESCRIPTION
I have been using today my guitar in the line in jack of my Zoom H2N (TS from guitar -> adapter to minijack TRS -> line in, and edited the files 
Rocksmith.ini
- Win32UltralowLatency = 1 (otherwise Rocksmith sound will not start)
- Latency Buffer =2 (less than that  provides crackling slowed sound)
RSASIO.ini to the appropriate driver (ZOOM H and S ASIO)
- BaseChannel = 0. 
ASIO configured to 16 bit, 48000hz, 256 buffer size